### PR TITLE
fix: missing XDG_DATA_DIRS environment variables

### DIFF
--- a/misc/Xsession.d/00deepin-dde-env
+++ b/misc/Xsession.d/00deepin-dde-env
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [ "$1" = "/usr/bin/startdde" ]; then
     if [ -f "$HOME/.dde_env" ]; then
         . "$HOME/.dde_env"
@@ -27,4 +29,16 @@ if [ "$1" = "/usr/bin/startdde" ]; then
     if [ $? -eq 0 ];then
         export QMLSCENE_DEVICE=softwarecontext
     fi
+
+    # https://man7.org/linux/man-pages/man7/systemd.environment-generator.7.html
+    # set the default value
+    XDG_DATA_DIRS="${XDG_DATA_DIRS:-/usr/local/share/:/usr/share}"
+
+    if [[ -d $HOME/.local/share/icons/ ]];
+    then
+        export XDG_DATA_DIRS="$HOME/.local/share/icons/:${XDG_DATA_DIRS}"
+    fi
+    export XDG_DATA_HOME="$HOME/.local/share"
+    export XDG_CONFIG_HOME="$HOME/.config"
+    export XDG_CACHE_HOME="$HOME/.cache"
 fi

--- a/misc/profile.d/deepin-xdg-dir.sh
+++ b/misc/profile.d/deepin-xdg-dir.sh
@@ -1,7 +1,3 @@
-export XDG_DATA_HOME="$HOME/.local/share"
-export XDG_CONFIG_HOME="$HOME/.config"
-export XDG_CACHE_HOME="$HOME/.cache"
-
 #export XDG_DESKTOP_DIR="$HOME/Desktop"
 #export XDG_DOCUMENTS_DIR="$HOME/Documents"
 #export XDG_DOWNLOAD_DIR="$HOME/Downloads"


### PR DESCRIPTION
set XDG_DATA_DIRS to $HOME/.local/share /usr/local/share /usr/share

Issue: Fixed https://github.com/linuxdeepin/developer-center/issues/2457
Log:

Resolve https://github.com/linuxdeepin/developer-center/issues/1675