### PR TITLE
chore: remove gvfs-bin dependency from control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -36,7 +36,6 @@ Depends:
  deepin-wm | deepin-metacity | dde-kwin,
  deepin-proxy,
  gnome-keyring,
- gvfs-bin,
  libpam-gnome-keyring,
  procps,
  xinput,


### PR DESCRIPTION
从 debian/control 中移除 gvfs-bin 依赖

gvfs 的使用应该是历史版本 https://github.com/linuxdeepin/startdde/commit/f5b19ce52e03bbce55edd24a08fb5733c2f1254b 所需，目前版本看上去不再包含对 gvfs 的直接调用了（并且 gvfs 已被 gio 取代，前者已被废弃）。此提交移除了对 gvfs-bin 的依赖声明。

这个提交是解决 https://github.com/linuxdeepin/developer-center/issues/3230 问题的一部分。