### PR TITLE
fix: 当主屏发生变化后，及时更新到xsettings

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+startdde (3.0.7) stable; urgency=low
+
+  * Autobuild Tag 3.0.7 
+
+ -- 范朋程 <fanpengcheng@uniontech.com>  Tue, 2 Aug 2022 14:41:16 +0800
+
 startdde (3.0.7-1) stable; urgency=low
 
   * Autobuild Tag 3.0.7 


### PR DESCRIPTION
dwayland通过xsettings获取主屏信息的变化，用于实现wayland下主屏设置功能
确保qt接口和display服务的主屏数据一致

Log: 解决wayland下主屏功能异常问题
Influence: 当主屏发生变化后，及时更新到xsettings
Bug: https://pms.uniontech.com/bug-view-146451.html