### PR TITLE
fix(display): 修复wayland下插拔显示器分辨率与配置不同步问题

### DIFF
--- a/display/manager.go
+++ b/display/manager.go
@@ -728,7 +728,7 @@ func (m *Manager) updateMonitorsId(options applyOptions) (changed bool) {
 	oldMonitorsId := m.monitorsId
 	monitorMap := m.cloneMonitorMap()
 	newMonitorsId := getConnectedMonitors(monitorMap).getMonitorsId()
-	if newMonitorsId != oldMonitorsId && newMonitorsId.v1 != "" {
+	if newMonitorsId != oldMonitorsId && (newMonitorsId.v1 != "" || _useWayland) {
 		m.monitorsId = newMonitorsId
 		logger.Debugf("monitors id changed, old monitors id: %v, new monitors id: %v", oldMonitorsId.v1, newMonitorsId.v1)
 		m.markClean()
@@ -1209,6 +1209,7 @@ func (m *Manager) addMonitor(monitorInfo *MonitorInfo) error {
 	}
 
 	logger.Debug("addMonitor", monitorInfo.Name)
+	monitorInfo.dumpForDebug()
 
 	monitor := &Monitor{
 		service:            m.service,


### PR DESCRIPTION
wayland 情况下插拔显示器会触发先移除后增加，由于无显示器情况下会出现空
id 的情况导致条件不成立，无法应用配置。

Log: 修复wayland下插拔显示器分辨率与配置不同步问题
Bug: https://pms.uniontech.com/bug-view-149827.html
Influence: 显示
Change-Id: I83fde33fa9a1a25bb2905396daec881d7731dca5