### PR TITLE
fix(display): 修复单屏下真实显示模式不正确的问题

### DIFF
--- a/display/manager_ifc.go
+++ b/display/manager_ifc.go
@@ -285,6 +285,11 @@ func (m *Manager) SetColorTemperature(value int32) *dbus.Error {
 func (m *Manager) GetRealDisplayMode() (uint8, *dbus.Error) {
 	monitors := m.getConnectedMonitors()
 
+	// 实际只有1屏（wayland 插拔情况）维持前状态
+	if len(monitors) == 1 {
+		return m.DisplayMode, nil
+	}
+
 	mode := DisplayModeUnknown
 	var pairs strv.Strv
 	for _, m := range monitors {


### PR DESCRIPTION
单屏下真实显示模式为仅单屏与设置的模式不一致，应维持上次显示模式。

Log: 修复扩展模式开机，副屏桌面未显示问题
Bug: https://pms.uniontech.com/bug-view-154359.html
Influence: 显示
Change-Id: I801d1af7b693de09f14e488d168e756dabd27f81