### PR TITLE
fix(display): 修复多屏下切换用户，插拔显示器恢复到上个用户配置显示模式

### DIFF
--- a/display/manager.go
+++ b/display/manager.go
@@ -2466,6 +2466,10 @@ func (m *Manager) saveSysConfigNoLock(reason string) error {
 		return nil
 	}
 
+	if !m.sessionActive {
+		return nil
+	}
+
 	m.sysConfig.UpdateAt = time.Now().Format(time.RFC3339Nano)
 	m.sysConfig.Version = sysConfigVersion
 


### PR DESCRIPTION
问题

多用户配置相互冲突

Log: 修复多屏下切换用户，插拔显示器恢复到上个用户配置显示模式
问题
Bug: https://pms.uniontech.com/bug-view-155839.html
Influence: 显示

Change-Id: I68780295f9d0c231fff03331705ef49a88b278e0