### PR TITLE
fix: 修复仅X屏下设置手动调节色温，然后切换仅另一个屏幕显示,再切换过来时，色温会恢复成默认未开启状态

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -31,6 +31,7 @@ prepare() {
   go get -v github.com/godbus/dbus/introspect
   go get -v github.com/godbus/dbus/prop
   go get -v gopkg.in/yaml.v3
+  go get -v github.com/davecgh/go-spew
   sed -i 's/sbin/bin/' Makefile
 }
 

--- a/display/manager.go
+++ b/display/manager.go
@@ -1809,7 +1809,7 @@ func (m *Manager) switchMode(mode byte, name string) (err error) {
 
 	monitorsId := monitors.getMonitorsId()
 	options := getSwitchModeOptions(mode, name)
-	err = m.switchModeAux(mode, oldMode, monitorsId, monitorMap, true, options)
+	err = m.switchModeAux(mode, oldMode, monitorsId, monitorMap, false, options)
 	if err != nil {
 		applyErr, ok := err.(*applyFailed)
 		if ok && applyErr.reason == reasonNumChanged {


### PR DESCRIPTION
切换显示模式时,设置色温的传参错误,从而恢复为0了,设置显示模式不应该去设置色温调节模式

Log: 修复仅X屏下设置手动调节色温，然后切换仅另一个屏幕显示,再切换过来时，色温会恢复成默认未开启状态
Bug: https://pms.uniontech.com/bug-view-156687.html
Influence: 色温调节