### PR TITLE
fix: 移除激活session更新触摸屏配置

### DIFF
--- a/display/manager.go
+++ b/display/manager.go
@@ -342,7 +342,6 @@ func newManager(service *dbusutil.Service) *Manager {
 			m.newSysCfg = nil
 		}
 
-		m.handleTouchscreenChanged()
 		m.showTouchscreenDialogs()
 
 		// 监听用户的session Active属性改变信号，当切换到当前已经登录的用户时


### PR DESCRIPTION
handleTouchscreenChanged会调用窗管接口，cgo里面的调用，窗管接口崩溃后导致startdde崩溃 添加该代码Bug：https://pms.uniontech.com/zentao/bug-view-78358.html 去除handleTouchscreenChanged后，未复现上述bug
先使用规避方案处理该bug
窗管崩溃问题，后续采取demo方式跟踪

Log: 移除激活session更新触摸屏配置
Influence: 多账户多屏切换账户
Bug: https://pms.uniontech.com/bug-view-156083.html
Change-Id: I9d8105b3f997825540b81a2dcd8fd1afbfbbbbd1