### PR TITLE
fix: 修复不同分辨率下切换复制模式时,高亮显示不全的问题

### DIFF
--- a/display/manager.go
+++ b/display/manager.go
@@ -1533,8 +1533,11 @@ func (m *Manager) handlePrimaryRectChanged(pmi *MonitorInfo) {
 	m.PropsMu.Lock()
 	defer m.PropsMu.Unlock()
 
-	m.setPropPrimary(pmi.Name)
-	m.setPropPrimaryRect(pmi.getRect())
+	// 复制模式不用设置主屏
+	if m.DisplayMode != DisplayModeMirror {
+		m.setPropPrimary(pmi.Name)
+		m.setPropPrimaryRect(pmi.getRect())
+	}
 }
 
 func (m *Manager) setPrimary(name string) error {


### PR DESCRIPTION
分辨率不同的情况下,切换复制模式触发了主屏设置,此时主屏设置在分辨率改变之前,导致大小错误
复制模式下不存在主副屏之分,不应该改变主副屏

Log: 修复不同分辨率下切换复制模式,高亮显示不全的问题
Bug: https://pms.uniontech.com/bug-view-147319.html
Influence: 显示模式