### PR TITLE
fix: 处理鼠标中键(滑轮)按下唤醒

### DIFF
--- a/session.go
+++ b/session.go
@@ -1384,8 +1384,8 @@ func initXEventMonitor() {
 	sigLoop.Start()
 	xEvent.InitSignalExt(sigLoop, true)
 	xEvent.ConnectButtonPress(func(button int32, x int32, y int32, id string) {
-		// 4表示鼠标中键上滑，5表示鼠标中键下滑
-		if button == 4 || button == 5 {
+		// 2表示按下鼠标中键，4表示鼠标中键上滑，5表示鼠标中键下滑
+		if button == 2 || button == 4 || button == 5 {
 			setDPMSMode(true)
 		}
 	})


### PR DESCRIPTION
2表示鼠标滑轮按下；
4表示鼠标滑轮上滑；
5表示鼠标滑轮下滑；

Log: 对鼠标中键，按下、上滑、下滑均做唤醒显示器处理
Influence: 鼠标滑轮操作唤醒显示器
Bug: https://pms.uniontech.com/bug-view-162365.html
Change-Id: I2ef5b0800a9ca5bcf0bd7dbd05ce73aa06d85271