### PR TITLE
fix: make 'wm-cmd' as preferred if non-empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,27 @@ func reapZombies() {
 }
 
 func shouldUseDDEKWin() bool {
-	_, err := os.Stat("/usr/bin/kwin_no_scale")
+	var (
+		wmCmd string
+		err   error
+	)
+
+	// for unit test
+	if _gSettingsConfig == nil {
+		goto end
+	}
+	wmCmd = _gSettingsConfig.wmCmd
+	if len(wmCmd) != 0 {
+		_, err = os.Stat(strings.Split(wmCmd, " ")[0])
+		if err == nil {
+			return false
+		}
+		// fallback
+		_gSettingsConfig.wmCmd = ""
+	}
+
+end:
+	_, err = os.Stat("/usr/bin/kwin_no_scale")
 	return err == nil
 }
 


### PR DESCRIPTION
Log: 修复 kwin 存在时设置 'wm-cmd' 不生效的问题
Influence: 用户可自定义窗管
Change-Id: I193b7b93312b4d559382cf20441e55b419d87d68