### PR TITLE
fix: 修复PGV拔掉HDMI线，插上VGA，桌面壁纸显示黑屏的问题

### DIFF
--- a/display/manager.go
+++ b/display/manager.go
@@ -1533,11 +1533,12 @@ func (m *Manager) handlePrimaryRectChanged(pmi *MonitorInfo) {
 	m.PropsMu.Lock()
 	defer m.PropsMu.Unlock()
 
-	// 复制模式不用设置主屏
-	if m.DisplayMode != DisplayModeMirror {
-		m.setPropPrimary(pmi.Name)
-		m.setPropPrimaryRect(pmi.getRect())
+	// 复制模式不用设置主屏，由于单屏和复制模式共用一个配置，因此此处需要判断屏幕个数来确实是否是复制模式
+	if (m.DisplayMode == DisplayModeMirror) && (len(m.monitorMap) > 1) {
+		return
 	}
+	m.setPropPrimary(pmi.Name)
+	m.setPropPrimaryRect(pmi.getRect())
 }
 
 func (m *Manager) setPrimary(name string) error {


### PR DESCRIPTION
由于单屏和复制模式共用配置文件，单屏也是复制模式，导致没有更新主屏

Log: 修复PGV拔掉HDMI线，插上VGA，桌面壁纸显示黑屏的问题
Bug: https://pms.uniontech.com/bug-view-166025.html
Influence: 主屏