### PR TITLE
fix: 规避休眠会多一个displaylink显示器问题

### DIFF
--- a/display/xorg.go
+++ b/display/xorg.go
@@ -392,15 +392,14 @@ func (mm *xMonitorManager) doDiff() {
 		}
 	}
 	newMap := toMonitorInfoMap(newMonitors)
-	if len(newMonitors) < len(oldMonitors) {
-		for k, monitor := range oldMonitors {
-			_, ok := newMap[k]
-			if !ok {
-				// 需要移除的monitor
-				mm.mu.Unlock()
-				mm.hooks.handleMonitorRemoved(monitor.ID)
-				mm.mu.Lock()
-			}
+	for k, monitor := range oldMonitors {
+		_, ok := newMap[k]
+		if !ok {
+			// 需要移除的monitor
+			mm.mu.Unlock()
+			logger.Info("remove monitor:", monitor.ID)
+			mm.hooks.handleMonitorRemoved(monitor.ID)
+			mm.mu.Lock()
 		}
 	}
 }


### PR DESCRIPTION
由于休眠唤醒后没有移除monitor信号,导致会多一个monitor,所以移除原来的判断条件,遍历原有的monitor,移除不存在的

Log: 规避待机会多一个displaylink显示器问题
Bug: https://pms.uniontech.com/bug-view-174637.html
Influence: displaylink
Change-Id: I4de93dba64e442cad59d5c9d04670c78e0886d6e