### PR TITLE
fix: 修复X100显卡不显示色温调节项的问题

### DIFF
--- a/misc/dsettings/org.deepin.Display.json
+++ b/misc/dsettings/org.deepin.Display.json
@@ -23,6 +23,17 @@
       "description": "",
       "permissions": "readwrite",
       "visibility": "private"
+    },
+    "special-gpu-vendor-list": {
+      "value": ["1ed5:","1db7:"],
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "special gpu vendor list",
+      "description": "",
+      "permissions": "readwrite",
+      "visibility": "private"
     }
   }
 }


### PR DESCRIPTION
部分显卡lspci没有VGA compatible controller相关数据，需要特殊处理

Log: 修复X100显卡不显示色温调节项的问题
Bug: https://pms.uniontech.com/bug-view-177571.html
Influence: 色温显示
Change-Id: I58a700046eaff5ef4b2fece3574b8e59dd8035ec