### PR TITLE
fix: 修复X100显卡不显示色温调节项的问题

### DIFF
--- a/display/manager.go
+++ b/display/manager.go
@@ -108,6 +108,7 @@ const (
 	DSettingsDisplayName                              = "org.deepin.Display"
 	DSettingsKeyHDMIIsBuiltinConfig                   = "HDMI-is-builtin"
 	DSettingsKeyBackLightMaxBrightnessChooseBigConfig = "backLight-max-brightness-choose-big"
+	DSettingsKeySpecialGPUVendorListConfig            = "special-gpu-vendor-list"
 )
 
 var (
@@ -235,6 +236,7 @@ type Manager struct {
 	dsBackLightMaxBrightnessChooseBigConfig []string
 	dmiInfo                                 systeminfo.DMIInfo
 	pciVendor                               []string
+	dsSpecialGPUVendorList                  []string
 }
 
 type monitorSizeInfo struct {
@@ -2946,14 +2948,20 @@ func (m *Manager) detectDrmSupportGamma() (bool, error) {
 		}
 	}
 	if !vgaSupportGamma {
-		args := []string{"-d 1ed5:"}
-		specifiedVendorInfo, err := getLspci(args)
-		if err != nil {
-			logger.Warning(err)
-			return false, err
-		}
-		if specifiedVendorInfo != "" {
-			vgaSupportGamma = true
+		// 部分显卡lspci没有VGA compatible controller相关数据，需要特殊处理
+		specialGPUVendorList := m.dsSpecialGPUVendorList
+		for _, vendor := range specialGPUVendorList {
+			args := []string{fmt.Sprintf("-d %s", vendor)}
+			specifiedVendorInfo, err := getLspci(args)
+			if err != nil {
+				logger.Warning(err)
+				vgaSupportGamma = false
+				continue
+			}
+			if specifiedVendorInfo != "" {
+				vgaSupportGamma = true
+				break
+			}
 		}
 	}
 	return vgaSupportGamma, nil
@@ -2996,8 +3004,20 @@ func (m *Manager) initDSettings(sysBus *dbus.Conn) {
 			m.dsBackLightMaxBrightnessChooseBigConfig = append(m.dsBackLightMaxBrightnessChooseBigConfig, i.Value().(string))
 		}
 	}
+	getSpecialGPUVendorList := func() {
+		v, err := dsDisplay.Value(0, DSettingsKeySpecialGPUVendorListConfig)
+		if err != nil {
+			logger.Warning(err)
+			return
+		}
+		itemList := v.Value().([]dbus.Variant)
+		for _, i := range itemList {
+			m.dsSpecialGPUVendorList = append(m.dsSpecialGPUVendorList, i.Value().(string))
+		}
+	}
 	getHDMIIsBuiltinConfig()
 	getBackLightMaxBrightnessChooseBigConfig()
+	getSpecialGPUVendorList()
 
 	dsDisplay.InitSignalExt(m.sysSigLoop, true)
 	_, err = dsDisplay.ConnectValueChanged(func(key string) {
@@ -3006,6 +3026,8 @@ func (m *Manager) initDSettings(sysBus *dbus.Conn) {
 			getHDMIIsBuiltinConfig()
 		case DSettingsKeyBackLightMaxBrightnessChooseBigConfig:
 			getBackLightMaxBrightnessChooseBigConfig()
+		case DSettingsKeySpecialGPUVendorListConfig:
+			getSpecialGPUVendorList()
 		}
 	})
 	if err != nil {

--- a/misc/dsettings/org.deepin.Display.json
+++ b/misc/dsettings/org.deepin.Display.json
@@ -23,6 +23,17 @@
       "description": "",
       "permissions": "readwrite",
       "visibility": "private"
+    },
+    "special-gpu-vendor-list": {
+      "value": ["1ed5:","1db7:"],
+      "serial": 0,
+      "flags": [
+        "global"
+      ],
+      "name": "special gpu vendor list",
+      "description": "",
+      "permissions": "readwrite",
+      "visibility": "private"
     }
   }
 }


### PR DESCRIPTION
部分显卡lspci没有VGA compatible controller相关数据，需要特殊处理

Log: 修复X100显卡不显示色温调节项的问题
Bug: https://pms.uniontech.com/bug-view-177571.html
Influence: 色温显示
Change-Id: I58a700046eaff5ef4b2fece3574b8e59dd8035ec