### PR TITLE
fix: 修复扩展模式切换到复制模式失效的问题

### DIFF
--- a/display/manager.go
+++ b/display/manager.go
@@ -1443,6 +1443,14 @@ func (m *Manager) applyModeMirror(monitorsId monitorsId, monitorMap map[uint32]*
 			return
 		}
 	}
+	for _, config := range configs {
+		if config.X != 0 || config.Y != 0 {
+			logger.Warning("mirror config is wrong, correct the config")
+			needSaveCfg = true
+			config.X = 0
+			config.Y = 0
+		}
+	}
 
 	err = m.applySysMonitorConfigs(DisplayModeMirror, monitorsId, monitorMap, configs, options)
 	if err != nil {


### PR DESCRIPTION
显示配置文件出错，设置复制模式之前校验文件数据

Log: 修复扩展模式切换到复制模式失效的问题
Bug: https://pms.uniontech.com/bug-view-180033.html
Influence: 切换显示模式