### PR TITLE
fix: 修复双触控屏双屏复制切换到仅X屏模式时实际效果依然为双屏复制模式的问题

### DIFF
--- a/display/displayconf.go
+++ b/display/displayconf.go
@@ -674,17 +674,33 @@ func (s *SysScreenConfig) setMonitorConfigsOnlyOne(uuid string, configs SysMonit
 		s.OnlyOneMap[uuid] = &SysMonitorModeConfig{}
 	}
 
+	logger.Debug("OnlyOneConfig lenth:", len(configs))
+	// 如果多个屏幕的UUID一样，则保存所有配置，根据屏幕名称区分应该点亮哪一个
 	if len(configs) > 1 {
-		// 去除非使能的 monitor
-		var tmpCfg *SysMonitorConfig
+		isRepeat := false
+		mapCfg := make(map[string]bool)
 		for _, config := range configs {
-			if config.Enabled {
-				tmpCfg = config
+			_, ok := mapCfg[config.UUID]
+			if ok {
+				logger.Debug("config uuid is repeat")
+				isRepeat = true
 				break
+			} else {
+				mapCfg[config.UUID] = true
 			}
 		}
-		if tmpCfg != nil {
-			configs = SysMonitorConfigs{tmpCfg}
+		if !isRepeat {
+			// 去除非使能的 monitor
+			var tmpCfg *SysMonitorConfig
+			for _, config := range configs {
+				if config.Enabled {
+					tmpCfg = config
+					break
+				}
+			}
+			if tmpCfg != nil {
+				configs = SysMonitorConfigs{tmpCfg}
+			}
 		}
 	}
 

--- a/display/manager.go
+++ b/display/manager.go
@@ -1748,7 +1748,6 @@ func (m *Manager) buildConfigForModeOnlyOne(monitors Monitors, uuid string) (mon
 			//cfg.Reflect = 0
 			cfg.Brightness = 1
 			monitorCfgs = append(monitorCfgs, cfg)
-			return
 		}
 	}
 	return
@@ -1803,6 +1802,13 @@ func (m *Manager) applyModeOnlyOne(monitorsId monitorsId, monitorMap map[uint32]
 		configs, err = m.buildConfigForModeOnlyOne(monitors, uuid)
 		if err != nil {
 			return
+		}
+	}
+
+	if len(m.Monitors) > 1 && len(configs) > 1 && name != "" {
+		for _, config := range configs {
+			config.Enabled = config.Name == name
+			logger.Debug("update OnlyOneConfig", config)
 		}
 	}
 


### PR DESCRIPTION
双触控屏的UUID一样，无法区分，设置之后通过屏幕的name进行区分

Log: 修复双触控屏双屏复制切换到仅X屏模式时实际效果依然为双屏复制模式的问题
Bug: https://pms.uniontech.com/bug-view-179173.html
Influence: 仅单屏显示