### PR TITLE
perf: 优化登录加载速度

### DIFF
--- a/display/manager.go
+++ b/display/manager.go
@@ -39,6 +39,7 @@ import (
 	"github.com/linuxdeepin/go-lib/xdg/basedir"
 	x "github.com/linuxdeepin/go-x11-client"
 	"github.com/linuxdeepin/go-x11-client/ext/randr"
+
 	"github.com/linuxdeepin/startdde/display/brightness"
 )
 
@@ -383,11 +384,12 @@ func newManager(service *dbusutil.Service) *Manager {
 	if err != nil {
 		logger.Warning(err)
 	}
-
-	m.drmSupportGamma, _ = m.detectDrmSupportGamma()
-	if m.drmSupportGamma {
-		m.setColorTempModeReal(ColorTemperatureModeNone)
-	}
+	go func() {
+		m.drmSupportGamma, _ = m.detectDrmSupportGamma()
+		if m.drmSupportGamma {
+			m.setColorTempModeReal(ColorTemperatureModeNone)
+		}
+	}()
 	return m
 }
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/linuxdeepin/go-lib/log"
 	"github.com/linuxdeepin/go-lib/proxy"
 	x "github.com/linuxdeepin/go-x11-client"
+
 	"github.com/linuxdeepin/startdde/display"
 	"github.com/linuxdeepin/startdde/iowait"
 	"github.com/linuxdeepin/startdde/watchdog"
@@ -374,13 +375,6 @@ func main() {
 	if err != nil {
 		logger.Warning("start display part1 failed:", err)
 	}
-
-	// NOTE: always start pulseaudio
-	err = startPulseAudio()
-	if err != nil {
-		logger.Warning("failed to start pulseaudio:", err)
-	}
-
 	launchCoreComponents(sessionManager)
 
 	// 启动 display 模块的后一部分
@@ -392,6 +386,8 @@ func main() {
 	}()
 
 	go func() {
+		// NOTE: always start pulseaudio
+		startPulseAudio()
 		initSoundThemePlayer()
 		playLoginSound()
 	}()

--- a/session_process.go
+++ b/session_process.go
@@ -131,6 +131,7 @@ func (m *SessionManager) launchWithoutWait(bin string, args ...string) {
 
 func (m *SessionManager) launch(bin string, wait bool, args ...string) bool {
 	if bin == "dde-session-daemon-part2" {
+		startPulseAudio()
 		return m.startSessionDaemonPart2()
 	}
 


### PR DESCRIPTION
1. 探测是否支持gamma值设置的逻辑放到协程中处理,drmSupportGamma属性在启动过程中不被需要;
2. 优化启动pulseaudio:因为该逻辑要在播放登录音效和dde-session-daemon的part2之前启动,因此在这两个之前分别使用sync.Once加载;

Log: 优化登录加载速度
Bug: https://pms.uniontech.com/bug-view-178975.html
Change-Id: I3fecc0d09b9ffe67fec79af4afb81ee8b12ccd74