### PR TITLE
feat: 为玲珑应用使用 dconfig 配置环境

### DIFF
--- a/misc/Xsession.d/00deepin-dde-env
+++ b/misc/Xsession.d/00deepin-dde-env
@@ -22,6 +22,11 @@ if [ "$1" = "/usr/bin/startdde" ]; then
             export QT_LOGGING_RULES="*.debug=false"
         fi
     fi
+    # set DSG_DATA_DIRS
+    if [[ -d "/persistent/linglong/entries/share/dsg" ]];
+    then
+        export DSG_DATA_DIRS="$DSG_DATA_DIRS:/usr/share/dsg:/persistent/linglong/entries/share/dsg"
+    fi
     # set qt qpa platform type
     export QT_QPA_PLATFORM=xcb
     # control qml softwarecontext in loongson-drm


### PR DESCRIPTION
玲珑应用会把配置文件安装到 /persistent/... 下
需要配置环境变量让 dde-dconfig-daemon 去相应目录
下遍历 meta 配置文件，否则玲珑应用无法使用 DConfig 功能

Log: dconfig support linglong app
Influecne: linglong app
Bug: https://pms.uniontech.com/bug-view-182341.html