### PR TITLE
chore: remove dde-api-proxy from dependencies list

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -46,7 +46,6 @@ Depends:
  dde-wldpms,
  redshift,
  dde-appearance,
- dde-api-proxy,
  ${misc:Depends},
  ${shlibs:Depends},
 Recommends:


### PR DESCRIPTION
移除 dde-api-proxy 依赖，不再默认提供 v20 DBus 兼容。

Influence: 所有仍在使用 v20 DDE 相关 DBus 的应用