### PR TITLE
chore: remove dde-kwin runtime dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,6 @@ Depends:
  deepin-desktop-schemas (>> 5.2.0+),
  deepin-turbo,
  deepin-turbo-booster,
- deepin-wm | deepin-metacity | dde-kwin,
  deepin-proxy,
  gnome-keyring,
  gvfs-bin,

--- a/rpm/startdde.spec
+++ b/rpm/startdde.spec
@@ -32,7 +32,6 @@ Requires:       dde-daemon
 Requires:       procps
 Requires:       gocode
 Requires:       deepin-desktop-schemas
-Requires:       dde-kwin
 Requires:       libXfixes
 Requires:       libXcursor
 Recommends:     dde-qt5integration


### PR DESCRIPTION
deepin-kwin provides the dde-kwin
