### PR TITLE
feat: 允许用户通过 force-scale-factor.ini 强制设置全局缩放

### DIFF
--- a/display/xorg.go
+++ b/display/xorg.go
@@ -98,6 +98,12 @@ func GetRecommendedScaleFactor() float64 {
 		return 1.0
 	}
 
+	// 允许用户通过 force-scale-factor.ini 强制设置全局缩放
+	forceScaleFactor, err := GetForceScaleFactor()
+	if err == nil {
+		return forceScaleFactor
+	}
+
 	minScaleFactor := 3.0
 	for _, monitor := range monitors {
 		scaleFactor := calcRecommendedScaleFactor(float64(monitor.width), float64(monitor.height),

--- a/wl_display/manager.go
+++ b/wl_display/manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/linuxdeepin/go-lib/dbusutil"
 	x "github.com/linuxdeepin/go-x11-client"
 	"github.com/linuxdeepin/go-x11-client/ext/randr"
+	display "github.com/linuxdeepin/startdde/display"
 	"github.com/linuxdeepin/startdde/wl_display/brightness"
 )
 
@@ -487,6 +488,13 @@ func (m *Manager) calcRecommendedScaleFactor() float64 {
 	if len(monitors) == 0 {
 		return 1.0
 	}
+
+	// 允许用户通过 force-scale-factor.ini 强制设置全局缩放
+	forceScaleFactor, err := display.GetForceScaleFactor()
+	if err == nil {
+		return forceScaleFactor
+	}
+
 	for _, monitor := range monitors {
 		scaleFactor := calcRecommendedScaleFactor(float64(monitor.Width), float64(monitor.Height),
 			float64(monitor.MmWidth), float64(monitor.MmHeight))


### PR DESCRIPTION
当前启动时会根据分辨率最小的屏幕设置全局缩放，这在某些场景下可能并不是用户想要的，比如用户有个高分屏是主屏幕，还有一个低分屏只用来看点简单的信息，当前的模式就会导致用户的主屏也无法正常以全局缩放模式正常使用。 该PR允许用户编辑`~/.config/deepin/force-scale-factor.ini`为如下内容，强制系统的全局缩放：
```
[ForceScaleFactor]
scale=1.5
```

Log: 允许用户通过 force-scale-factor.ini 强制设置全局缩放