### PR TITLE
chore: remove gvfs-bin dependency from control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,6 @@ Depends:
  deepin-desktop-schemas (>> 5.2.0+),
  deepin-proxy,
  gnome-keyring,
- gvfs-bin,
  libpam-gnome-keyring,
  procps,
  xinput,


### PR DESCRIPTION
从 debian/control 中移除 gvfs-bin 依赖。

v23 合并的时候丢失的提交，重新应用此提交： https://github.com/linuxdeepin/startdde/pull/150