### PR TITLE
fix: Makefile中systemd target wants链接到构建临时目录

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ install:
 
 	mkdir -p $(DESTDIR)$(PREFIX)/lib/systemd/user/dde-session-daemon.target.wants/
 	install -v -m0644 misc/systemd_task/dde-display-task-refresh-brightness.service $(DESTDIR)$(PREFIX)/lib/systemd/user/
-	ln -s $(DESTDIR)$(PREFIX)/lib/systemd/user/dde-display-task-refresh-brightness.service $(DESTDIR)$(PREFIX)/lib/systemd/user/dde-session-daemon.target.wants/dde-display-task-refresh-brightness.service
+	ln -s $(PREFIX)/lib/systemd/user/dde-display-task-refresh-brightness.service $(DESTDIR)$(PREFIX)/lib/systemd/user/dde-session-daemon.target.wants/dde-display-task-refresh-brightness.service
 
 
 clean:


### PR DESCRIPTION
在Arch Linux上构建不会纠正链接目录。