### PR TITLE
chore: clean redundance code

### DIFF
--- a/main.go
+++ b/main.go
@@ -158,11 +158,6 @@ func main() {
 		}
 	}()
 
-	go func() {
-		initSoundThemePlayer()
-		playLoginSound()
-	}()
-
 	err = gsettings.StartMonitor()
 	if err != nil {
 		logger.Warning("gsettings start monitor failed:", err)


### PR DESCRIPTION
play login sound has been implement in dde-session, so startdde not need to do that

Log: