### PR TITLE
feat: 支持插件设置护眼模式

### DIFF
--- a/display/color_temp.go
+++ b/display/color_temp.go
@@ -238,6 +238,9 @@ func (m *Manager) saveColorTempValueInCfg(value int32) {
 func (m *Manager) saveColorTempModeInCfg(mode int32) {
 	m.modifySuitableUserMonitorModeConfig(func(cfg *UserMonitorModeConfig) {
 		cfg.ColorTemperatureMode = mode
+		if cfg.ColorTemperatureMode != ColorTemperatureModeNone {
+			cfg.ColorTemperatureModeOn = cfg.ColorTemperatureMode
+		}
 	})
 	err := m.saveUserConfig()
 	if err != nil {

--- a/display/displayconf.go
+++ b/display/displayconf.go
@@ -72,6 +72,7 @@ const (
 type UserMonitorModeConfig struct {
 	ColorTemperatureMode   int32
 	ColorTemperatureManual int32
+	ColorTemperatureModeOn int32 //记录用户开启色温时的模式
 	// 以后如果有必要
 	// Monitors UserMonitorConfigs
 }
@@ -82,6 +83,9 @@ func (c *UserMonitorModeConfig) fix() {
 	}
 	if !isValidColorTempValue(c.ColorTemperatureManual) {
 		c.ColorTemperatureManual = defaultTemperatureManual
+	}
+	if c.ColorTemperatureMode != ColorTemperatureModeNone {
+		c.ColorTemperatureModeOn = c.ColorTemperatureMode
 	}
 }
 
@@ -97,6 +101,8 @@ func getDefaultUserMonitorModeConfig() *UserMonitorModeConfig {
 	return &UserMonitorModeConfig{
 		ColorTemperatureMode:   defaultTemperatureMode,
 		ColorTemperatureManual: defaultTemperatureManual,
+		// TODO: 如果配置缺失，需要一个色温使能的模式
+		ColorTemperatureModeOn: ColorTemperatureModeAuto,
 	}
 }
 


### PR DESCRIPTION
插件设置护眼模式开关，控制中心色温做联动；
本地保存色温开启时的配置，以供护眼模式使能时恢复配置