### PR TITLE
chore: 将屏幕的初始化放在init中，init的调用应该在dbus 接口export之后，这样属性变化才会有信号发出

### DIFF
--- a/display/display.go
+++ b/display/display.go
@@ -92,7 +92,6 @@ func (m *Manager) setScaleFactors(factors map[string]float64) error {
 
 func Start(service *dbusutil.Service) error {
 	m := newManager(service)
-	m.init()
 
 	if !_greeterMode {
 		// 正常 startdde
@@ -133,6 +132,7 @@ func Start(service *dbusutil.Service) error {
 			return err
 		}
 	}
+	m.init()
 	_dpy = m
 	return nil
 }

--- a/display/manager.go
+++ b/display/manager.go
@@ -263,16 +263,6 @@ func newManager(service *dbusutil.Service) *Manager {
 	m.sessionSigLoop = sessionSigLoop
 	sessionSigLoop.Start()
 
-	if _useWayland {
-		m.mm = newKMonitorManager(sessionSigLoop)
-	} else {
-		m.mm = newXMonitorManager(m.xConn, _hasRandr1d2)
-	}
-
-	m.mm.setHooks(m)
-
-	m.setPropMaxBacklightBrightness(uint32(brightness.GetMaxBacklightBrightness()))
-
 	m.sysBus, err = dbus.SystemBus()
 	if err != nil {
 		logger.Warning(err)
@@ -916,6 +906,16 @@ func (m *Manager) migrateOldConfig() {
 }
 
 func (m *Manager) init() {
+	// 屏幕的初始化应该放在init中
+	if _useWayland {
+		m.mm = newKMonitorManager(m.sessionSigLoop)
+	} else {
+		m.mm = newXMonitorManager(m.xConn, _hasRandr1d2)
+	}
+
+	m.mm.setHooks(m)
+
+	m.setPropMaxBacklightBrightness(uint32(brightness.GetMaxBacklightBrightness()))
 	brightness.InitBacklightHelper()
 	brightness.SetUseWayland(_useWayland)
 	m.initDebugOptions()


### PR DESCRIPTION
将屏幕的初始化放在init中，init的调用应该在dbus 接口export之后，这样属性变化才会有信号发出